### PR TITLE
changed top and left bounds for look

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -82,11 +82,11 @@ function Player(team, homeLocation, world) {
         case 'wait':
           return yld();
         case 'look':
-          if (args[0] === 'up' && ant.position.y - 1 > 0) {
+          if (args[0] === 'up' && ant.position.y > 0) {
             return raw(world.map.map[ant.position.y - 1][ant.position.x].type);
           } else if (args[0] === 'down' && ant.position.y + 1 < world.map.map.length) {
             return raw(world.map.map[ant.position.y + 1][ant.position.x].type);
-          } else if (args[0] === 'left' && ant.position.x - 1 > 0) {
+          } else if (args[0] === 'left' && ant.position.x > 0) {
             return raw(world.map.map[ant.position.y][ant.position.x - 1].type);
           } else if (args[0] === 'right' && ant.position.x + 1 < world.map.map[0].length) {
             return raw(world.map.map[ant.position.y][ant.position.x + 1].type);


### PR DESCRIPTION
Look was previously returning false if an ant was one tile away from the top or the left, because of an off by one error. This changes the bound so that look('up') returns false if position.y < 1 and look('left') returns false if position.x < 1
